### PR TITLE
Add default values to `--help` output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -337,7 +337,7 @@ class Args {
 
     if (version) {
       // If it exists, register it as a default option
-      this.option('version', 'Output the version number', version)
+      this.option('version', 'Output the version number')
 
       // And immediately output it if used in command line
       if (this.raw.v || this.raw.version) {

--- a/src/index.js
+++ b/src/index.js
@@ -197,7 +197,7 @@ class Args {
 
     // Set option defaults
     for (const option of this.details.options) {
-      if (!option.defaultValue) {
+      if (typeof option.defaultValue === 'undefined') {
         continue
       }
 
@@ -274,15 +274,19 @@ class Args {
     })[0].usage.length
 
     for (const item of items) {
-      let {usage, description} = item
+      let {usage, description, defaultValue} = item
       const difference = longest - usage.length
 
       // Compensate the difference to longest property with spaces
       usage += ' '.repeat(difference)
 
       // Add some space around it as well
-      if (typeof item.defaultValue !== 'undefined') {
-        description += ` (defaults to ${JSON.stringify(item.defaultValue)})`
+      if (typeof defaultValue !== 'undefined') {
+        if (typeof defaultValue === 'boolean') {
+          description += ` (${defaultValue ? 'enabled' : 'disabled'} by default)`
+        } else {
+          description += ` (defaults to ${JSON.stringify(defaultValue)})`
+        }
       }
       parts.push('  ' + chalk.yellow(usage) + '  ' + chalk.dim(description))
     }

--- a/src/index.js
+++ b/src/index.js
@@ -274,14 +274,14 @@ class Args {
     })[0].usage.length
 
     for (const item of items) {
-      let { usage, description } = item
+      let {usage, description} = item
       const difference = longest - usage.length
 
       // Compensate the difference to longest property with spaces
       usage += ' '.repeat(difference)
 
       // Add some space around it as well
-      if ('undefined' !== typeof item.defaultValue) {
+      if (typeof item.defaultValue !== 'undefined') {
         description += ` (defaults to ${JSON.stringify(item.defaultValue)})`
       }
       parts.push('  ' + chalk.yellow(usage) + '  ' + chalk.dim(description))

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,7 @@ class Args {
       case parseInt:
         return ['<n>', parseInt]
       default:
-        return false
+        return ['']
     }
   }
 
@@ -274,14 +274,17 @@ class Args {
     })[0].usage.length
 
     for (const item of items) {
-      let usage = item.usage
+      let { usage, description } = item
       const difference = longest - usage.length
 
       // Compensate the difference to longest property with spaces
       usage += ' '.repeat(difference)
 
       // Add some space around it as well
-      parts.push('  ' + chalk.yellow(usage) + '  ' + chalk.dim(item.description))
+      if ('undefined' !== typeof item.defaultValue) {
+        description += ` (defaults to ${JSON.stringify(item.defaultValue)})`
+      }
+      parts.push('  ' + chalk.yellow(usage) + '  ' + chalk.dim(description))
     }
 
     return parts

--- a/test/index.js
+++ b/test/index.js
@@ -89,7 +89,7 @@ test('command aliases', async t => {
   }
 
   result = await run('help')
-  const regexes = [/binary, b/, /cmd/, /-a, --abc \[value\]/]
+  const regexes = [/binary, b/, /cmd/, /-a, --abc \[value]/]
   for (const regex of regexes) {
     t.regex(result, regex)
   }


### PR DESCRIPTION
Fixes #38.

I also fixed a bug with Boolean types showing `undefined` in the output.

Before:

```
    -b, --b undefined  a boolean type
    -l, --l <list>     a list type
    -n, --n <n>        a number type
    -o, --o            no default value
    -s, --s [value]    a string type
```

Now:

```
    -b, --b          a boolean type (defaults to true)
    -l, --l <list>   a list type (defaults to [1,2,3])
    -n, --n <n>      a number type (defaults to 42)
    -o, --o          no default value
    -s, --s [value]  a string type (defaults to "milk")
```

Thought: for bool types we could say "on" or "enabled" (and "off" or "disabled")
instead of true/false to make the output a little bit more human-friendly.