### PR TITLE
Typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,56 @@
+declare var args: Args.API;
+export = args;
+
+declare namespace Args {
+    export interface IMinimistUnknownFunction {
+        (param: string): boolean
+    }
+
+    export interface IMinimistArguments {
+        string?: string | string[];
+        boolean?: boolean | string | string[];
+        alias?: any;
+        default?: any;
+        stopEarly?: boolean;
+        "--"?: boolean;
+        unknown?: IMinimistUnknownFunction;
+    }
+
+    export interface IOptionInitFunction {
+        (value: any): void;
+    }
+
+    export interface ICommandInitFunction {
+        (name: string, sub: {}[], options: {}[]): void;
+    }
+
+    export interface IUsageFilterFunction {
+        (output: any): any;
+    }
+
+    export interface IConfiguration {
+        help?: boolean;
+        name?: string;
+        version?: boolean;
+        usageFilter?: IUsageFilterFunction;
+        value?: string;
+        minimist?: IMinimistArguments;
+    }
+
+    export interface IOption {
+        name: string;
+        description: string;
+        init?: IOptionInitFunction;
+        defaultValue?: any;
+    }
+
+    export interface API {
+        sub: string[],
+
+        option(name: string, description: string, defaultValue?: any, init?: IOptionInitFunction): void,
+        options(list: IOption[]): void,
+        command(name: string, description: string, init?: ICommandInitFunction, aliases?: string[]): void,
+        parse(argv: string[], options: IConfiguration): void,
+        showHelp(): void,
+    }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "args",
   "version": "2.2.4",
   "description": "Minimal toolkit for building CLIs",
+  "types": "index.d.ts",
   "files": [
     "index.js"
   ],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Minimal toolkit for building CLIs",
   "types": "index.d.ts",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "test": "xo && ava"


### PR DESCRIPTION
Created a typescript definitions file as per your API documentation in your `README`.

Usage in typescript would remain `import * as args from "args"`.

Its the first definitions file I created alone so not 100% sure if this is the best way to do it but I based my work off of the [DefinitelyTyped/winston](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/winston/index.d.ts) implementation, and I can confirm that it works fine in my project.