### PR TITLE
Transform duplicated short flag to upper case

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,13 +50,18 @@ class Args {
   option(name, description, defaultValue, init) {
     let usage = []
 
+    const assignShort = (name, options, short) => {
+      if (options.find(flagName => flagName.usage[0] === short)) {
+        short = name.charAt(0).toUpperCase()
+      }
+      return [short, name]
+    }
+
     // If name is an array, pick the values
     // Otherwise just use the whole thing
     switch (name.constructor) {
       case String:
-        usage[0] = name.charAt(0)
-        usage[1] = name
-
+        usage = assignShort(name, this.details.options, name.charAt(0))
         break
       case Array:
         usage = usage.concat(name)

--- a/test/index.js
+++ b/test/index.js
@@ -16,13 +16,16 @@ const argv = [
   'foo',
   '-p',
   port.toString(),
-  '--data'
+  '--data',
+  '--D',
+  'D'
 ]
 
 test('options', t => {
   args
     .option('port', 'The port on which the site will run')
     .option(['d', 'data'], 'The data that shall be used')
+    .option('duplicated', 'Duplicated first char in option')
 
   const config = args.parse(argv)
 
@@ -34,6 +37,9 @@ test('options', t => {
     const content = config[property]
 
     switch (content) {
+      case 'D':
+        t.is(content, 'D')
+        break
       case version:
         t.is(content, version)
         break


### PR DESCRIPTION
If you specify two options with the same first letter, the second one gets transformed to uppercase by default.

`example.js`:

```js
#!/usr/bin/env node

const args = require('./')

args
  .option('debug', 'Run Debug mode')
  .option('deploy', 'Deploy')

const flags = args.parse(process.argv)
```

`$ node example.js help`:

```
  Usage: example.js [options] [command]
  
  Commands:
  
    help  Display help
  
  Options:
  
    -d, --debug    Run Debug mode
    -D, --deploy   Deploy
    -h, --help     Output usage information
    -v, --version  Output the version number
```

Note that the `--deploy` short-flag is now capitalized