### PR TITLE
Fix bug in #55

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,8 +186,10 @@ class Args {
         }
       }
 
-      // Camelcase option name
-      name = camelcase(name)
+      // Camelcase option name (skip short flag)
+      if (name.length > 1) {
+        name = camelcase(name)
+      }
 
       // Add option to list
       contents[name] = propVal


### PR DESCRIPTION
I noticed, that this method #55  does not work, because the short flag option always gets converted to lowercase.
This PR only converts the long flags to camelcase

testfile.js:
`$ node testfile.js -D`
```javascript
const args = require('args')

args.option('deploy', 'deploy')
.option(['D', 'deps'], 'dependencies')
const flags = args.parse(process.argv)

console.log(flags.D, flags.d) // undefined, true
```