### PR TITLE
Bump node version in engines field, remove loud-rejection dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This package makes creating command line interfaces a breeze.
 
 ## Usage
 
-Install the package (you'll need at least v6 of [Node](https://nodejs.org/en/)):
+Install the package (you'll need at least v6.6 of [Node](https://nodejs.org/en/)):
 
 ```bash
 npm install --save args

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const spawn = require('child_process').spawn
 // Packages
 const parser = require('minimist')
 const pkginfo = require('pkginfo')
-const loudRejection = require('loud-rejection')
 const camelcase = require('camelcase')
 const chalk = require('chalk')
 
@@ -27,9 +26,6 @@ class Args {
       value: null,
       name: null
     }
-
-    // Make unhandled promise rejections fail loudly instead of the default silent fail
-    loudRejection()
   }
 
   options(list) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": "leo/args",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.6.0"
   },
   "keywords": [
     "cli",
@@ -46,7 +46,6 @@
   "dependencies": {
     "camelcase": "4.0.0",
     "chalk": "1.1.3",
-    "loud-rejection": "1.3.0",
     "minimist": "1.2.0",
     "pkginfo": "0.4.0"
   }


### PR DESCRIPTION
I noticed the README says args only supports Node 6+. If that's the case, then it seems the `loud-rejection` could be eliminated.

**Changes**
- Remove `loud-rejection` dependency
  - [Since Node 6.6.0, unhandled promises are loud by default](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#2016-09-14-version-660-current-fishrock123)
- Update node version in `engines` package.json field to `>= 6.6.0`