### PR TITLE
Change output colors in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -497,13 +497,13 @@ class Args {
       groups[group] = false
     }
 
-    const optionHandle = groups.options ? ' [options]' : ''
-    const cmdHandle = groups.commands ? ' [command]' : ''
+    const optionHandle = groups.options ? '[options] ' : ''
+    const cmdHandle = groups.commands ? '[command]' : ''
     const value = typeof this.config.value === 'string' ? ' ' + this.config.value : ''
 
     parts.push([
       '',
-      'Usage: ' + this.printMainColor(name) + this.printSubColor(optionHandle + cmdHandle + value),
+      `Usage: ${this.printMainColor(name)} ${this.printSubColor(optionHandle + cmdHandle + value)}`,
       ''
     ])
 

--- a/index.js
+++ b/index.js
@@ -24,8 +24,13 @@ class Args {
       version: true,
       usageFilter: null,
       value: null,
-      name: null
+      name: null,
+      maincolor: 'yellow',
+      subColor: 'dim'
     }
+
+    this.printMainColor = chalk
+    this.printSubColor = chalk
   }
 
   options(list) {
@@ -297,7 +302,7 @@ class Args {
           description += ` (defaults to ${JSON.stringify(defaultValue)})`
         }
       }
-      parts.push('  ' + chalk.yellow(usage) + '  ' + chalk.dim(description))
+      parts.push('  ' + this.printMainColor(usage) + '  ' + this.printSubColor(description))
     }
 
     return parts
@@ -405,6 +410,30 @@ class Args {
     // Override default option values
     Object.assign(this.config, options)
 
+    if (Array.isArray(this.config.mainColor)) {
+      for (const item in this.config.mainColor) {
+        if (!{}.hasOwnProperty.call(this.config.mainColor, item)) {
+          continue
+        }
+        // chain all colors to our print method
+        this.printMainColor = this.printMainColor[this.config.mainColor[item]]
+      }
+    } else {
+      this.printMainColor = this.printMainColor[this.config.mainColor]
+    }
+
+    if (Array.isArray(this.config.subColor)) {
+      for (const item in this.config.subColor) {
+        if (!{}.hasOwnProperty.call(this.config.subColor, item)) {
+          continue
+        }
+        // chain all colors to our print method
+        this.printSubColor = this.printSubColor[this.config.subColor[item]]
+      }
+    } else {
+      this.printSubColor = this.printSubColor[this.config.subColor]
+    }
+
     if (this.config.help) {
       // Register default options and commands
       this.option('help', 'Output usage information')
@@ -474,7 +503,7 @@ class Args {
 
     parts.push([
       '',
-      'Usage: ' + chalk.yellow(name) + chalk.dim(optionHandle + cmdHandle + value),
+      'Usage: ' + this.printMainColor(name) + this.printSubColor(optionHandle + cmdHandle + value),
       ''
     ])
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class Args {
       usageFilter: null,
       value: null,
       name: null,
-      maincolor: 'yellow',
+      mainColor: 'yellow',
       subColor: 'dim'
     }
 

--- a/readme.md
+++ b/readme.md
@@ -162,8 +162,8 @@ By default, the module already registers some default options (e.g. "version" an
 | usageFilter | Allows you to specify a filter through which the usage information will be passed before it gets outputted | null | Function |
 | value | Suffix for the "Usage" section of the usage information ([example](https://github.com/leo/args/issues/13)) | null | String |
 | minimist | Additional parsing options to pass to minimist, see [minimist docs](https://github.com/substack/minimist) for details | undefined | Object |
-| mainColor | Specify the main color for the output when running the `help` command. See [chalk docs](https://github.com/chalk/chalk) for available colors / modifiers | yellow | String[Array] |
-| subColor | Specify the sub color for the output when running the `help` command. See [chalk docs](https://github.com/chalk/chalk) for available colors / modifiers | dim | String[Array] |
+| mainColor | Specify the main color for the output when running the `help` command. See [chalk docs](https://github.com/chalk/chalk) for available colors / modifiers. You can specify multiple colors / modifiers with an array. For example: `{mainColor: ['red', 'bold', 'underline']}` | yellow | String[Array] |
+| subColor | Specify the sub color for the output when running the `help` command. See [chalk docs](https://github.com/chalk/chalk) for available colors / modifiers. You can specify multiple colors / modifiers with an array. For example: `{subColor: ['dim', 'blue']}` | dim | String[Array] |
 
 You can pass the configuration object as the second paramater of [.parse()](#parseargv-options).
 

--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,8 @@ By default, the module already registers some default options (e.g. "version" an
 | usageFilter | Allows you to specify a filter through which the usage information will be passed before it gets outputted | null | Function |
 | value | Suffix for the "Usage" section of the usage information ([example](https://github.com/leo/args/issues/13)) | null | String |
 | minimist | Additional parsing options to pass to minimist, see [minimist docs](https://github.com/substack/minimist) for details | undefined | Object |
+| mainColor | Specify the main color for the output when running the `help` command. See [chalk docs](https://github.com/chalk/chalk) for available colors / modifiers | yellow | String[Array] |
+| subColor | Specify the sub color for the output when running the `help` command. See [chalk docs](https://github.com/chalk/chalk) for available colors / modifiers | dim | String[Array] |
 
 You can pass the configuration object as the second paramater of [.parse()](#parseargv-options).
 


### PR DESCRIPTION
Related: #64 

```js
args
.option('deploy', 'Deploy')

args.parse(process.argv, {mainColor: ['red', 'bold'], subColor: 'underline'})
```

<img width="358" alt="screenshot at feb 26 18-03-40" src="https://cloud.githubusercontent.com/assets/8714775/23341753/fc05d578-fc4d-11e6-9f0c-a8299fddb9d3.png">
