### PR TITLE
Update --help usage. Closes #58.

### DIFF
--- a/index.js
+++ b/index.js
@@ -451,7 +451,7 @@ class Args {
     }
 
     const subCommand = this.raw._[1]
-    const helpTriggered = this.raw.h || this.raw.help
+    const helpTriggered = !!this.raw.help
 
     const args = {}
     const defined = this.isDefined(subCommand, 'commands')

--- a/index.js
+++ b/index.js
@@ -53,8 +53,11 @@ class Args {
 
     const assignShort = (name, options, short) => {
       if (options.find(flagName => flagName.usage[0] === short)) {
-        if (name === 'help') short = false
-        else short = name.charAt(0).toUpperCase()
+        if (name === 'help') {
+          short = false
+        } else {
+          short = name.charAt(0).toUpperCase()
+        }
       }
       return [short, name]
     }
@@ -451,7 +454,7 @@ class Args {
     }
 
     const subCommand = this.raw._[1]
-    const helpTriggered = !!this.raw.help
+    const helpTriggered = this.raw.help
 
     const args = {}
     const defined = this.isDefined(subCommand, 'commands')

--- a/index.js
+++ b/index.js
@@ -53,7 +53,8 @@ class Args {
 
     const assignShort = (name, options, short) => {
       if (options.find(flagName => flagName.usage[0] === short)) {
-        short = name.charAt(0).toUpperCase()
+        if (name === 'help') short = false
+        else short = name.charAt(0).toUpperCase()
       }
       return [short, name]
     }
@@ -265,7 +266,7 @@ class Args {
           usage = usage.join(', ')
         } else {
           const isVersion = usage.indexOf('v')
-          usage = `-${usage[0]}, --${usage[1]}`
+          usage = usage[0] ? `-${usage[0]}, --${usage[1]}` : `--${usage[1]}`
 
           if (!initial) {
             initial = items[item].init

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ In turn, this is how the auto-generated usage information will look like:
 
     -v, --version  Output the version number
     -r, --reload   Enable/disable livereloading
-    -h, --help     Output usage information
+    --help         Output usage information
     -p, --port     The port on which the app will be running
 
 ```
@@ -156,7 +156,7 @@ By default, the module already registers some default options (e.g. "version" an
 
 | Property | Description | Default&nbsp;value | Type |
 | -------- | ----------- | ------------------ | ---- |
-| help | Automatically render the usage information when running `help`, `-h` or `--help` | true | Boolean |
+| help | Automatically render the usage information when running `help` or `--help` | true | Boolean |
 | name | The name of your program to display in help | Name of script file | String |
 | version | Outputs the version tag of your package.json | true | Boolean |
 | usageFilter | Allows you to specify a filter through which the usage information will be passed before it gets outputted | null | Function |


### PR DESCRIPTION
Hey @leo,

I updated `args` to only allow the `--help` flag, closing issue #58.

This is definitely the right move, since creating an option that starts with an _h_, such at `headers`, creates a conflict. The `help` short flag becomes `-H`, but the check to show the help menu is still `this.raw.h || this.raw.help`, so the help menu is printed if something like `gest -h Accept=application/json` is executed. This is even further complicated if the user wants to allow both the `-h` and `-H` flags.

The reason for `if (name === 'help') short = false` is because then then `usage.length > 0 && usage[0].length > 1` will still be false in `option()`.

Let me know if you would like me to make updates. I love `args` and really want to use it for my upcoming `graphicli` tool!