### PR TITLE
Fix ENOENT error for spawning child processes

### DIFF
--- a/index.js
+++ b/index.js
@@ -323,7 +323,7 @@ class Args {
     }
 
     // Generate full name of binary
-    const full = this.binary + '-' + (Array.isArray(details.usage) ? details.usage[0] : details.usage)
+    const full = path.join(__dirname, this.binary + '-' + (Array.isArray(details.usage) ? details.usage[0] : details.usage))
 
     const args = process.argv
     let i = 0


### PR DESCRIPTION
Hey @leo,

This fix might not be necessary, but when I created my first `args` subcommand I got:

```
Error: spawn gest-test ENOENT
    at exports._errnoException (util.js:1028:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:359:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    ...
```

and using `__dirname` was my quick fix. Let me know if you see a better solution (like using the command -> file map in `package.json`'s `bin`).