### PR TITLE
Fix bug in option value with booleans

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ class Args {
   }
 
   readOption(option) {
-    let value = false;
+    let value = option.defaultValue;
     const contents = {};
 
     // If option has been used, get its value

--- a/test/index.js
+++ b/test/index.js
@@ -16,6 +16,7 @@ const argv = ['node', 'foo', '-p', port.toString(), '--data', '--D', 'D'];
 test('options', t => {
   args
     .option('port', 'The port on which the site will run')
+    .option('true', 'Boolean', true)
     .option(['d', 'data'], 'The data that shall be used')
     .option('duplicated', 'Duplicated first char in option');
 


### PR DESCRIPTION
Testfile `ex.js`:
```js
const args = require('./')

args
  .option('booltrue', 'bool true', true)
  .option('boolfalse', 'bool false', false)
  .option('empty', 'empty')
  .option('string', 'string', 'str')
  .option('list', 'list', [1,2,3])
  .option('num', 'num', 5000)

console.error(args.parse(process.argv))
```

Output:
```bash
~/dev/args [*fix-#71*]
❯ node ex.js
{ b: true,
  booltrue: true,
  B: false,
  boolfalse: false,
  s: 'str',
  string: 'str',
  l: [ 1, 2, 3 ],
  list: [ 1, 2, 3 ],
  n: 5000,
  num: 5000 }
```

```bash
❯ node  ex.js help

  Usage: ex.js [options] [command]

  Commands:

    help  Display help

  Options:

    -B, --boolfalse       bool false (disabled by default)
    -b, --booltrue        bool true (enabled by default)
    -e, --empty           empty
    -h, --help            Output usage information
    -l, --list <list>     list (defaults to [1,2,3])
    -n, --num <n>         num (defaults to 5000)
    -s, --string [value]  string (defaults to "str")
    -v, --version         Output the version number
```

This fixes #71 