### PR TITLE
Display help when subcommand is unknown

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const parser = require('minimist');
 const pkginfo = require('pkginfo');
 const camelcase = require('camelcase');
 const chalk = require('chalk');
+const didYouMean = require('didyoumean2');
 
 class Args {
   constructor() {
@@ -518,6 +519,7 @@ class Args {
     const args = {};
     const defined = this.isDefined(subCommand, 'commands');
     const optionList = this.getOptions();
+    const unknownSubcommand = !defined && subCommand;
 
     Object.assign(args, this.raw);
     args._.shift();
@@ -531,9 +533,19 @@ class Args {
       return {};
     }
 
-    // Show usage information if "help" or "h" option was used
+    if (unknownSubcommand) {
+      const availableSubcommands = this.details.commands.map(sub => sub.usage);
+      const suggestSubcommand = didYouMean(subCommand, availableSubcommands);
+      console.log(`\nUnknown Subcommand ${this.printMainColor(subCommand)}`);
+
+      if (suggestSubcommand !== null) {
+        console.log(`Did you mean ${this.printMainColor(suggestSubcommand)}?`);
+      }
+    }
+
+    // Show usage information if "help" or "h" ogit dtdtusption was used
     // And respect the option related to it
-    if (this.config.help && helpTriggered) {
+    if ((this.config.help && helpTriggered) || unknownSubcommand) {
       this.showHelp();
     }
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const parser = require('minimist');
 const pkginfo = require('pkginfo');
 const camelcase = require('camelcase');
 const chalk = require('chalk');
-const didYouMean = require('didyoumean2');
+const stringSimilarity = require('string-similarity');
 
 class Args {
   constructor() {
@@ -535,15 +535,21 @@ class Args {
 
     if (unknownSubcommand) {
       const availableSubcommands = this.details.commands.map(sub => sub.usage);
-      const suggestSubcommand = didYouMean(subCommand, availableSubcommands);
+      const suggestSubcommand = stringSimilarity.findBestMatch(
+        subCommand,
+        availableSubcommands
+      );
       console.log(`\nUnknown Subcommand ${this.printMainColor(subCommand)}`);
 
-      if (suggestSubcommand !== null) {
-        console.log(`Did you mean ${this.printMainColor(suggestSubcommand)}?`);
+      if (suggestSubcommand.bestMatch.rating >= 0.5) {
+        // 0.5 rating will catch small typos, e.g. import => omport
+        console.log(
+          `Did you mean ${this.printMainColor(suggestSubcommand.bestMatch.target)}?`
+        );
       }
     }
 
-    // Show usage information if "help" or "h" ogit dtdtusption was used
+    // Show usage information if "help" or "h" option was used
     // And respect the option related to it
     if ((this.config.help && helpTriggered) || unknownSubcommand) {
       this.showHelp();

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "camelcase": "4.0.0",
     "chalk": "1.1.3",
+    "didyoumean2": "1.3.0",
     "minimist": "1.2.0",
     "pkginfo": "0.4.0"
   }

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   "dependencies": {
     "camelcase": "4.0.0",
     "chalk": "1.1.3",
-    "didyoumean2": "1.3.0",
     "minimist": "1.2.0",
-    "pkginfo": "0.4.0"
+    "pkginfo": "0.4.0",
+    "string-similarity": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "args",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Minimal toolkit for building CLIs",
   "files": [
     "index.js"

--- a/readme.md
+++ b/readme.md
@@ -196,6 +196,7 @@ As always, you can run the [AVA](https://github.com/sindresorhus/ava) and [ESLin
 
 ... to [Dmitry Smolin](https://github.com/dimsmol) who donated the package name. If you're looking for the old content (before I've added my stuff) of the package, you can find it [here](https://github.com/dimsmol/args).
 
-## Author
+## Authors
 
-Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo))
+- Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo))
+- Marvin Mieth ([@ntwcklng](https://twitter.com/ntwcklng))


### PR DESCRIPTION
#73 

In addition, we check if the user may typed in a typo e.g.
```js
const args = require('../args')

args
.option('port', 'Specify the port', 3000)
.command('import', 'import')
.command('export', 'export')

const flags = args.parse(process.argv)
```
Running with the unknown Subcommand `omport` would output
```bash
❯ node args.js omport

Unknown Subcommand omport
Did you mean import?

  Usage: args.js [options] [command]

  Commands:

    export  export
    help    Display help
    import  import

  Options:

    -h, --help      Output usage information
    -p, --port <n>  Specify the port (defaults to 3000)
    -v, --version   Output the version number


```