### PR TITLE
Fix option suggestion when running a subcommand

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ class Args {
     return contents;
   }
 
-  getOptions() {
+  getOptions(definedSubcommand) {
     const options = {};
     const args = {};
 
@@ -259,7 +259,9 @@ class Args {
       if (related) {
         const details = this.readOption(related);
         Object.assign(options, details);
-      } else {
+      }
+
+      if (!related && !definedSubcommand) {
         // Unknown Option
         const availableOptions = [].concat(
           ...this.details.options.map(opt => opt.usage)
@@ -555,7 +557,7 @@ class Args {
 
     const args = {};
     const defined = this.isDefined(subCommand, 'commands');
-    const optionList = this.getOptions();
+    const optionList = this.getOptions(defined);
 
     Object.assign(args, this.raw);
     args._.shift();


### PR DESCRIPTION
We iterate through the options from the main command, even when you run a subcommand and we `process.exit()` too early because we can't find an option for your subcommand in your main command. To prevent that, we now check if the subcommand is defined.

This fixes #86.