### PR TITLE
Convert the option value to an array if the defaultValue is an array

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,6 +43,14 @@ module.exports = {
     for (let name of option.usage) {
       let propVal = value;
 
+      // Convert the value to an array when the option is called just once
+      if (
+        Array.isArray(option.defaultValue) &&
+        typeof propVal !== typeof option.defaultValue
+      ) {
+        propVal = [propVal];
+      }
+
       if (
         typeof option.defaultValue !== 'undefined' &&
         typeof propVal !== typeof option.defaultValue

--- a/test/index.js
+++ b/test/index.js
@@ -20,13 +20,16 @@ const argv = [
   '--D',
   'D',
   '-a',
-  'anotheroptionvalue'
+  'anotheroptionvalue',
+  '-l',
+  10
 ];
 
 test('options', t => {
   args
     .option('port', 'The port on which the site will run')
     .option('true', 'Boolean', true)
+    .option('list', 'List', [])
     .option(['d', 'data'], 'The data that shall be used')
     .option('duplicated', 'Duplicated first char in option')
     .options([{ name: 'anotheroption', description: 'another option' }]);
@@ -39,6 +42,7 @@ test('options', t => {
     }
 
     const content = config[property];
+    console.log(content);
 
     switch (content) {
       case 'D':
@@ -58,7 +62,11 @@ test('options', t => {
         }
         break;
       default:
-        t.true(content);
+        if (content.constructor === Array) {
+          t.deepEqual(content, [10]);
+        } else {
+          t.true(content);
+        }
     }
   }
 });

--- a/test/index.js
+++ b/test/index.js
@@ -42,7 +42,6 @@ test('options', t => {
     }
 
     const content = config[property];
-    console.log(content);
 
     switch (content) {
       case 'D':


### PR DESCRIPTION
If the option.defaultValue is an `Array` and you call the option just once we will convert the value to an `Array`. E.g.
```js
const args = require('args')
args.option('param', 'Parameter', [])
const flags = args.parse(process.argv)
console.log(flags.p)
```
Before:
```sh
$ program -p 10
[]
```
After:
```sh
$ program -p 10
[10]
```
This fixes https://github.com/leo/args/issues/90#issuecomment-299456207