### PR TITLE
pass in parent module from `index.js`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,8 @@ function Args() {
 
   this.printMainColor = chalk;
   this.printSubColor = chalk;
+
+  this.parent = module.parent;
 }
 
 // Assign internal helpers

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -45,7 +45,7 @@ module.exports = function(argv, options) {
 
   // If default version is allowed, check for it
   if (this.config.version) {
-    this.checkVersion();
+    this.checkVersion(this.parent);
   }
 
   const subCommand = this.raw._[1];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -318,9 +318,7 @@ module.exports = {
     });
   },
 
-  checkVersion() {
-    const parent = module.parent;
-
+  checkVersion(parent) {
     // Load parent module
     pkginfo(parent);
 


### PR DESCRIPTION
Since this is the entry point to the module, we need
to grab `module.parent` from here and not in utils.js,
otherwise we would end up with the `module` object from
`index.js` and grab args' version instead of the CLI app's
version.