### PR TITLE
make args robust against pkginfo error

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -322,8 +322,8 @@ module.exports = {
     // Load parent module
     try {
       pkginfo(parent);
-    } catch (e) {
-      // do nothing, but version could not be aquired
+    } catch (err) {
+      // Do nothing, but version could not be aquired
     }
 
     // And get its version property

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -320,10 +320,14 @@ module.exports = {
 
   checkVersion(parent) {
     // Load parent module
-    pkginfo(parent);
+    try {
+      pkginfo(parent);
+    } catch (e) {
+      // do nothing, but version could not be aquired
+    }
 
-    // And get its version propery
-    const version = parent.exports.version;
+    // And get its version property
+    const version = parent.exports.version || '-/-';
 
     if (version) {
       // If it exists, register it as a default option


### PR DESCRIPTION
pkginfo will throw if it cant find a package.json. this can happen if pkg (compile js into executable) is used to bundle/compile a js-script. 

if this is merged it is necessary to up the version for pkginfo (which is not yet existing)