### PR TITLE
Require pkginfo only if needed

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,6 @@
 
 const spawn = require('child_process').spawn;
 const path = require('path');
-const pkginfo = require('pkginfo');
 const camelcase = require('camelcase');
 const stringSimilarity = require('string-similarity');
 
@@ -341,6 +340,7 @@ module.exports = {
   checkVersion(parent) {
     // Load parent module
     try {
+      const pkginfo = require('pkginfo');
       pkginfo(parent);
     } catch (err) {
       // Do nothing, but version could not be aquired


### PR DESCRIPTION
I'm working on embedding `hpm` in `hyper`.
`hpm` obviously uses your wonderful lib.

And I have a problem with it. Because I'm using webpack to pack `hpm` in a single standalone file. And in this case `pkginfo` is not compatible. Requiring it directly throw an exception:
```
/Users/chabou/Documents/Projets/hyper/bin/cli.js:11586
    throw new Error('Could not find package.json up from ' +
    ^

Error: Could not find package.json up from 125
    at Function.pkginfo.find (/Users/chabou/Documents/Projets/hyper/bin/cli.js:11586:11)
    at Function.pkginfo.read (/Users/chabou/Documents/Projets/hyper/bin/cli.js:11613:22)
    at module.exports (/Users/chabou/Documents/Projets/hyper/bin/cli.js:11559:21)
    at Object.<anonymous> (/Users/chabou/Documents/Projets/hyper/bin/cli.js:11620:1)
    at Object.webpackEmptyContext.keys (/Users/chabou/Documents/Projets/hyper/bin/cli.js:11626:30)
    at __webpack_require__ (/Users/chabou/Documents/Projets/hyper/bin/cli.js:20:30)
    at Object.<anonymous> (/Users/chabou/Documents/Projets/hyper/bin/cli.js:11128:17)
    at __webpack_require__ (/Users/chabou/Documents/Projets/hyper/bin/cli.js:20:30)
    at Object.<anonymous> (/Users/chabou/Documents/Projets/hyper/bin/cli.js:10280:15)
    at Object.<anonymous> (/Users/chabou/Documents/Projets/hyper/bin/cli.js:10336:30)
```

I found some explanations here: https://github.com/meteor/meteor/issues/6313#issuecomment-188371347

Offending lines in `pkginfo` are: https://github.com/indexzero/node-pkginfo/blob/f4e90ac77034ee9eb3dd7aafc56657d7376795a8/lib/pkginfo.js#L129-L133

This previous PR: https://github.com/leo/args/pull/97 add some robustness against `pkg` but this is not enough with webpack.

This PR make it work if getting version is disabled.

I'm not sure if a webpack option could fix it but this PR do not change `args` features