### PR TITLE
Allow setting option init without default value

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -50,10 +50,11 @@ module.exports = function(name, description, defaultValue, init) {
       defaultIsWrong = false;
   }
 
-  // Set initializer depending on type of default value
-  if (!defaultIsWrong) {
-    const initFunction = typeof init === 'function';
-    optionDetails.init = initFunction ? init : this.handleType(defaultValue)[1];
+  if (typeof init === 'function') {
+    optionDetails.init = init;
+  } else if (!defaultIsWrong) {
+    // Set initializer depending on type of default value
+    optionDetails.init = this.handleType(defaultValue)[1];
   }
 
   // Register option to global scope


### PR DESCRIPTION
The init method didn't run when configuring an option without a default value, like this:

```
args
    .options([
        {
            name: 'theme',
            description: 'Build a specific theme in app/design',
            init: val => Array.isArray(val) ? val : [ val ], // Didn't run
        },
        {
            name: 'module',
            description: 'Build a specific module in app/code/local or vendor/',
            defaultValue: [],
            init: val => Array.isArray(val) ? val : [ val ], // Default value defined, runs correctly
        },
        ...
    ]);
```

I changed the logic slightly so that a default value is not required if you define an init method.