### PR TITLE
fix(defaults): Process help and version defaults better

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -22,13 +22,14 @@ module.exports = function() {
 
   const optionHandle = groups.options ? '[options] ' : '';
   const cmdHandle = groups.commands ? '[command]' : '';
-  const value = typeof this.config.value === 'string'
-    ? ' ' + this.config.value
-    : '';
+  const value =
+    typeof this.config.value === 'string' ? ' ' + this.config.value : '';
 
   parts.push([
     '',
-    `Usage: ${this.printMainColor(name)} ${this.printSubColor(optionHandle + cmdHandle + value)}`,
+    `Usage: ${this.printMainColor(name)} ${this.printSubColor(
+      optionHandle + cmdHandle + value
+    )}`,
     ''
   ]);
 
@@ -68,6 +69,8 @@ module.exports = function() {
 
   console.log(output);
 
-  // eslint-disable-next-line unicorn/no-process-exit
-  process.exit();
+  if (this.config.exit && this.config.exit.help) {
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit();
+  }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,7 @@ function Args() {
 
   // Configuration defaults
   this.config = {
+    exit: { help: true, version: true },
     help: true,
     version: true,
     usageFilter: null,
@@ -34,8 +35,6 @@ function Args() {
 
   this.printMainColor = chalk;
   this.printSubColor = chalk;
-
-  this.parent = module.parent;
 }
 
 // Assign internal helpers

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,8 @@ const publicMethods = {
   parse: require('./parse'),
   example: require('./example'),
   examples: require('./examples'),
-  showHelp: require('./help')
+  showHelp: require('./help'),
+  showVersion: require('./version')
 };
 
 function Args() {

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -33,24 +33,21 @@ module.exports = function(argv, options) {
     this.printSubColor = this.printSubColor[this.config.subColor];
   }
 
-  if (this.config.help) {
-    // Register default options and commands
-    this.option('help', 'Output usage information');
-    this.command('help', 'Display help', this.showHelp);
-  }
-
   // Parse arguments using mri
   this.raw = parser(argv.slice(1), this.config.mri || this.config.minimist);
   this.binary = path.basename(this.raw._[0]);
 
   // If default version is allowed, check for it
   if (this.config.version) {
-    this.checkVersion(this.parent);
+    this.checkVersion();
+  }
+
+  // If default help is allowed, check for it
+  if (this.config.help) {
+    this.checkHelp();
   }
 
   const subCommand = this.raw._[1];
-  const helpTriggered = this.raw.h || this.raw.help;
-
   const args = {};
   const defined = this.isDefined(subCommand, 'commands');
   const optionList = this.getOptions(defined);
@@ -65,12 +62,6 @@ module.exports = function(argv, options) {
   if (defined) {
     this.runCommand(defined, optionList);
     return {};
-  }
-
-  // Show usage information if "help" or "h" option was used
-  // And respect the option related to it
-  if (this.config.help && helpTriggered) {
-    this.showHelp();
   }
 
   // Hand back list of options

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -288,12 +288,15 @@ module.exports = {
       : details.usage;
     let full = this.binary + '-' + subCommand;
 
-    const args = process.argv;
-    let i = 0;
+    // Remove node and original command.
+    const args = process.argv.slice(2);
 
-    while (i < 3) {
-      args.shift();
-      i++;
+    // Remove the first occurance of subCommand from the args.
+    for (let i = 0, l = args.length; i < l; i++) {
+      if (args[i] === subCommand) {
+        args.splice(i, 1);
+        break;
+      }
     }
 
     if (process.platform === 'win32') {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -184,7 +184,7 @@ module.exports = {
       typeof kind === 'string' ? this.details[kind] : kind
     );
     for (let i = 0, l = passed.length; i < l; i++) {
-      items.push({ ...passed[i] });
+      items.push(Object.assign({}, passed[i]));
     }
 
     const parts = [];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -177,7 +177,16 @@ module.exports = {
 
   generateDetails(kind) {
     // Get all properties of kind from global scope
-    const items = typeof kind === 'string' ? this.details[kind] : kind;
+    const items = [];
+
+    // Clone passed objects so changing them here doesn't affect real data.
+    const passed = [].concat(
+      typeof kind === 'string' ? this.details[kind] : kind
+    );
+    for (let i = 0, l = passed.length; i < l; i++) {
+      items.push({ ...passed[i] });
+    }
+
     const parts = [];
     const isCmd = kind === 'commands';
 
@@ -358,14 +367,14 @@ module.exports = {
     }
   },
 
-  checkVersion(parent) {
+  checkVersion() {
     // Register default option and command.
     this.option('version', 'Output the version number');
     this.command('version', 'Display version', this.showVersion);
 
     // Immediately output if option was provided.
     if (this.optionWasProvided('version')) {
-      this.showVersion(parent);
+      this.showVersion();
     }
   },
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -269,6 +269,11 @@ module.exports = {
       details.init = false;
     }
 
+    // If version is disabled, remove initializer
+    if (details.usage === 'version' && !this.config.version) {
+      details.init = false;
+    }
+
     // If command has initializer, call it
     if (details.init) {
       const sub = [].concat(this.sub);
@@ -293,7 +298,9 @@ module.exports = {
 
     if (process.platform === 'win32') {
       const binaryExt = path.extname(this.binary);
-      const mainModule = process.env.APPVEYOR ? '_fixture' : process.mainModule.filename;
+      const mainModule = process.env.APPVEYOR
+        ? '_fixture'
+        : process.mainModule.filename;
 
       full = `${mainModule}-${subCommand}`;
 
@@ -337,29 +344,25 @@ module.exports = {
     });
   },
 
-  checkVersion(parent) {
-    // Load parent module
-    try {
-      const pkginfo = require('pkginfo');
-      pkginfo(parent);
-    } catch (err) {
-      // Do nothing, but version could not be aquired
+  checkHelp() {
+    // Register default option and command.
+    this.option('help', 'Output usage information');
+    this.command('help', 'Display help', this.showHelp);
+
+    // Immediately output if option was provided.
+    if (this.optionWasProvided('help')) {
+      this.showHelp();
     }
+  },
 
-    // And get its version property
-    const version = parent.exports.version || '-/-';
+  checkVersion(parent) {
+    // Register default option and command.
+    this.option('version', 'Output the version number');
+    this.command('version', 'Display version', this.showVersion);
 
-    if (version) {
-      // If it exists, register it as a default option
-      this.option('version', 'Output the version number');
-
-      // And immediately output it if used in command line
-      if (this.raw.v || this.raw.version) {
-        console.log(version);
-
-        // eslint-disable-next-line unicorn/no-process-exit
-        process.exit();
-      }
+    // Immediately output if option was provided.
+    if (this.optionWasProvided('version')) {
+      this.showVersion(parent);
     }
   },
 
@@ -383,5 +386,10 @@ module.exports = {
 
     // If nothing matches, item is not defined
     return false;
+  },
+
+  optionWasProvided(name) {
+    const option = this.isDefined(name, 'options');
+    return option && (this.raw[option.usage[0]] || this.raw[option.usage[1]]);
   }
 };

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function findPackage(directory) {
+  const file = path.resolve(directory, 'package.json');
+  if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+    return file;
+  }
+  const parent = path.resolve(directory, '..');
+  if (parent === directory) {
+    return null;
+  }
+  return findPackage(parent);
+}
+
+module.exports = function(parent) {
+  // The runCommand method passes the definition's usage, which in this case is "version".
+  // @todo The "parent" parameter should be removed once BC support is no longer needed.
+  parent = !parent || parent === 'version' ? this.parent : parent;
+
+  const filename = parent && parent.filename;
+  const dir = filename && path.dirname(filename);
+  const file = dir && findPackage(dir);
+  const pkg = (file && require(file)) || {};
+  const version = pkg.version || '-/-';
+
+  console.log(version);
+
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit();
+};

--- a/lib/version.js
+++ b/lib/version.js
@@ -3,24 +3,27 @@
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * Retrieves the main module package.json information.
+ *
+ * @param {string} directory
+ *   The directory to start looking in.
+ *
+ * @return {Object|null}
+ *   An object containing the package.json contents or NULL if it could not be found.
+ */
 function findPackage(directory) {
   const file = path.resolve(directory, 'package.json');
   if (fs.existsSync(file) && fs.statSync(file).isFile()) {
-    return file;
+    return require(file);
   }
   const parent = path.resolve(directory, '..');
-  if (parent === directory) {
-    return null;
-  }
-  return findPackage(parent);
+  return parent === directory ? null : findPackage(parent);
 }
 
 module.exports = function() {
-  const filename = module.parent && module.parent.filename;
-  const dir = filename && path.dirname(filename);
-  const file = dir && findPackage(dir);
-  const pkg = (file && require(file)) || {};
-  const version = pkg.version || '-/-';
+  const pkg = findPackage(path.dirname(process.mainModule.filename));
+  const version = (pkg && pkg.version) || '-/-';
 
   console.log(version);
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -15,12 +15,8 @@ function findPackage(directory) {
   return findPackage(parent);
 }
 
-module.exports = function(parent) {
-  // The runCommand method passes the definition's usage, which in this case is "version".
-  // @todo The "parent" parameter should be removed once BC support is no longer needed.
-  parent = !parent || parent === 'version' ? this.parent : parent;
-
-  const filename = parent && parent.filename;
+module.exports = function() {
+  const filename = module.parent && module.parent.filename;
   const dir = filename && path.dirname(filename);
   const file = dir && findPackage(dir);
   const pkg = (file && require(file)) || {};
@@ -28,6 +24,8 @@ module.exports = function(parent) {
 
   console.log(version);
 
-  // eslint-disable-next-line unicorn/no-process-exit
-  process.exit();
+  if (this.config.exit && this.config.exit.version) {
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit();
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -340,9 +340,27 @@
       "dev": true,
       "requires": {
         "arr-exclude": "1.0.0",
+        "execa": "0.7.0",
         "has-yarn": "1.0.0",
         "read-pkg-up": "2.0.0",
         "write-pkg": "3.1.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        }
       }
     },
     "babel-code-frame": {
@@ -4995,11 +5013,6 @@
         "find-up": "2.1.0"
       }
     },
-    "pkginfo": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
-    },
     "plur": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
@@ -5751,7 +5764,27 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "execa": "0.7.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        }
+      }
     },
     "text-table": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "camelcase": "4.1.0",
     "chalk": "2.1.0",
     "mri": "1.1.0",
-    "pkginfo": "0.4.1",
     "string-similarity": "1.2.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -165,14 +165,19 @@ pizza eat ./directory
 
 ### .showHelp()
 
-Outputs the usage information based on the options and comments you've registered so far.
+Outputs the usage information based on the options and comments you've registered so far and exits, if configured to do so.
+
+### .showVersion()
+
+Outputs the version and exits, if configured to do so.
 
 ## Configuration
 
-By default, the module already registers some default options (e.g. "version" and "help"), as well as a command named "help". These things have been implemented to make creating CLIs easier for beginners. However, they can also be disabled by taking advantage of the following properties:
+By default, the module already registers some default options and commands (e.g. "version" and "help"). These things have been implemented to make creating CLIs easier for beginners. However, they can also be disabled by taking advantage of the following properties:
 
 | Property | Description | Default&nbsp;value | Type |
 | -------- | ----------- | ------------------ | ---- |
+| exit | Automatically exits when help or version is rendered  | `{ help: true, version: true }` | Object |
 | help | Automatically render the usage information when running `help`, `-h` or `--help` | true | Boolean |
 | name | The name of your program to display in help | Name of script file | String |
 | version | Outputs the version tag of your package.json | true | Boolean |


### PR DESCRIPTION
The predefined `help` and `version` options are hardcoded to the lowercase characters when checking if they were provided.

This causes issues if other options like `host` or `verbose` are provided first, which actually does cause the `help` and `version` short options to be uppercased, but are ultimately ignored.

## Summary of changes:

#### Fixes

- Hard coded `help`/`version` short options. If someone provides `-v` for `verbose`, they actually get the version printed out and the process exits (this may also possibly help with #103 somewhat):
  Before: `foo bar -v` -> `1.0.0`
  After: `foo bar -v` -> `Verbose output from bar`
- Options passed before command:
  Before: `foo -dv bar -f file.txt` -> `foo-bar -f file.txt`
  After: `foo -dv bar -f file.txt` -> `foo-bar -dv -f file.txt`
- Bug in `generateDetails` where it was overriding the `usage` property on the items it was generating, which in turn was also altering the original object and causing the tests to bork.
- Updated documentation

#### Added

- An `exit` config option like was described in #95 (needed for tests)

#### Removed

- The `parent` parameter that was added to `checkVersion` in #96. Since this was only introduced in 3.0.2 and has remained an internal method (not exposed until now), there's no real risk of breaking BC.
- The `pkginfo` dependency - This module is unnecessary and, quite frankly, a little too presumptuous in populating metadata onto the module object. While, perhaps useful for other projects, it is overkill for simply attempting to retrieve the main module's version.