### PR TITLE
Compact layout

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -26,8 +26,7 @@ module.exports = function() {
     typeof this.config.value === 'string' ? ' ' + this.config.value : ''
 
   parts.push([
-    '',
-    `Usage: ${this.printMainColor(name)} ${this.printSubColor(
+    `  Usage: ${this.printMainColor(name)} ${this.printSubColor(
       optionHandle + cmdHandle + value
     )}`,
     ''
@@ -38,7 +37,7 @@ module.exports = function() {
       continue
     }
 
-    parts.push(['', firstBig(group) + ':', '', ''])
+    parts.push(['', firstBig(group) + ':', ''])
 
     if (group === 'examples') {
       parts.push(this.generateExamples())

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -185,7 +185,7 @@ module.exports = {
       }
       const usage = this.printSubColor('$ ' + examples[item].usage)
       const description = this.printMainColor('- ' + examples[item].description)
-      parts.push(`  ${description}\n\n    ${usage}\n\n`)
+      parts.push(`  ${description}\n    ${usage}\n`)
     }
 
     return parts

--- a/test/_fixture.js
+++ b/test/_fixture.js
@@ -24,4 +24,14 @@ args.command('cmd', 'cmd desc', () => {
 
 args.command('binary', 'some desc', ['b'])
 args.option(['a', 'abc'], 'something', 'def value')
+args.examples([
+  {
+    usage: 'args install -d',
+    description: 'Run the args command with the option -d'
+  },
+  {
+    usage: 'args uninstall -d',
+    description: 'Another description here'
+  }
+])
 args.parse(process.argv)


### PR DESCRIPTION
This PR  makes the default output take up less space in the terminal by removing some extra line breaks. Here's a before/after:

<img width="320" alt="before" src="https://user-images.githubusercontent.com/184567/40385995-ca2792e4-5e08-11e8-85ad-ec1e322351cc.png"> <img width="320" alt="after" src="https://user-images.githubusercontent.com/184567/40385996-ca47615a-5e08-11e8-9459-8d3999263d00.png">

Ideally we would also remove the extra two line breaks at the end but I could not figure out how to remove them?

Closes #123. 