### PR TITLE
Update readme.md usage example use commonjs instead of es6 module import

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Once you're done, you can start using it within your binaries:
 ```js
 #!/usr/bin/env node
 
-import args from 'args'
+const args = require('args')
 
 args
   .option('port', 'The port on which the app will be running', 3000)


### PR DESCRIPTION
Use ES6 modules in Node.js need save file with .mjs extension and run it like:
```bash
node --experimental-modules my-app.mjs
```